### PR TITLE
fix: stdout corruption, bootc fallback, GC race in get_hardware_report

### DIFF
--- a/cmd/bluefin-mcp/main.go
+++ b/cmd/bluefin-mcp/main.go
@@ -1,12 +1,10 @@
 package main
 
 import (
-	"context"
 	"fmt"
+	"log"
 	"os"
-	"os/signal"
 	"path/filepath"
-	"syscall"
 
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/projectbluefin/bluefin-mcp/internal/cli"
@@ -17,15 +15,10 @@ import (
 var version = "dev"
 
 func main() {
-	// Save the real stdout fd BEFORE redirecting os.Stdout. The MCP protocol
-	// uses fd 1 for JSON-RPC responses; we must keep a handle to it even after
-	// we point Go's os.Stdout variable at stderr to prevent stray fmt.Print*
-	// calls from corrupting the protocol stream.
-	realStdout := os.NewFile(1, "/dev/stdout")
-
-	// Redirect Go's os.Stdout so any stray fmt.Print* calls go to stderr
-	// instead of corrupting the JSON-RPC protocol stream.
-	os.Stdout = os.Stderr
+	// All logging must go to stderr — stdout is reserved for the JSON-RPC
+	// protocol stream. Every fmt.Fprintf call here already uses os.Stderr
+	// explicitly; this ensures the default logger also never writes to stdout.
+	log.SetOutput(os.Stderr)
 
 	if len(os.Args) > 1 && os.Args[1] == "--version" {
 		fmt.Fprintf(os.Stderr, "bluefin-mcp %s\n", version)
@@ -48,23 +41,7 @@ func main() {
 	s := server.NewMCPServer("bluefin-mcp", version)
 	tools.Register(s, runner, store)
 
-	// Use NewStdioServer + Listen (not ServeStdio) so we can pass realStdout
-	// explicitly. ServeStdio calls s.Listen(ctx, os.Stdin, os.Stdout) internally,
-	// but os.Stdout has been redirected above — all responses would go to stderr.
-	// Mirror ServeStdio's signal handling so SIGTERM/SIGINT still trigger a
-	// clean shutdown.
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGTERM, syscall.SIGINT)
-	go func() {
-		<-sigChan
-		cancel()
-	}()
-
-	stdio := server.NewStdioServer(s)
-	if err := stdio.Listen(ctx, os.Stdin, realStdout); err != nil {
+	if err := server.ServeStdio(s); err != nil {
 		fmt.Fprintf(os.Stderr, "server error: %v\n", err)
 		os.Exit(1)
 	}

--- a/cmd/bluefin-mcp/main.go
+++ b/cmd/bluefin-mcp/main.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"os/signal"
 	"path/filepath"
+	"syscall"
 
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/projectbluefin/bluefin-mcp/internal/cli"
@@ -14,8 +17,14 @@ import (
 var version = "dev"
 
 func main() {
-	// CRITICAL: redirect stdout to stderr BEFORE any other output.
-	// Any write to stdout corrupts the JSON-RPC MCP protocol.
+	// Save the real stdout fd BEFORE redirecting os.Stdout. The MCP protocol
+	// uses fd 1 for JSON-RPC responses; we must keep a handle to it even after
+	// we point Go's os.Stdout variable at stderr to prevent stray fmt.Print*
+	// calls from corrupting the protocol stream.
+	realStdout := os.NewFile(1, "/dev/stdout")
+
+	// Redirect Go's os.Stdout so any stray fmt.Print* calls go to stderr
+	// instead of corrupting the JSON-RPC protocol stream.
 	os.Stdout = os.Stderr
 
 	if len(os.Args) > 1 && os.Args[1] == "--version" {
@@ -39,7 +48,23 @@ func main() {
 	s := server.NewMCPServer("bluefin-mcp", version)
 	tools.Register(s, runner, store)
 
-	if err := server.ServeStdio(s); err != nil {
+	// Use NewStdioServer + Listen (not ServeStdio) so we can pass realStdout
+	// explicitly. ServeStdio calls s.Listen(ctx, os.Stdin, os.Stdout) internally,
+	// but os.Stdout has been redirected above — all responses would go to stderr.
+	// Mirror ServeStdio's signal handling so SIGTERM/SIGINT still trigger a
+	// clean shutdown.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGTERM, syscall.SIGINT)
+	go func() {
+		<-sigChan
+		cancel()
+	}()
+
+	stdio := server.NewStdioServer(s)
+	if err := stdio.Listen(ctx, os.Stdin, realStdout); err != nil {
 		fmt.Fprintf(os.Stderr, "server error: %v\n", err)
 		os.Exit(1)
 	}

--- a/internal/system/bootc.go
+++ b/internal/system/bootc.go
@@ -44,9 +44,10 @@ type bootcStatusJSON struct {
 
 type rpmOstreeJSON struct {
 	Deployments []struct {
-		Booted   bool   `json:"booted"`
-		Checksum string `json:"checksum"`
-		Origin   string `json:"origin"`
+		Booted            bool   `json:"booted"`
+		Checksum          string `json:"checksum"`
+		Origin            string `json:"origin"`
+		ContainerImageRef string `json:"container-image-reference"`
 	} `json:"deployments"`
 }
 
@@ -57,11 +58,7 @@ func GetSystemStatus(ctx context.Context, runner cli.CommandRunner) (*SystemStat
 	if err == nil {
 		return parseBootcJSON(out)
 	}
-	if !errors.Is(err, cli.ErrNotInstalled) {
-		return nil, err
-	}
-
-	// Fallback to rpm-ostree
+	// Fall back to rpm-ostree on any bootc failure (e.g. bootc requires root on some systems)
 	out, err = runner.Run(ctx, "rpm-ostree", []string{"status", "--json"})
 	if err != nil {
 		return nil, err
@@ -95,7 +92,15 @@ func parseRpmOstreeJSON(data []byte) (*SystemStatus, error) {
 	st := &SystemStatus{Source: "rpm-ostree"}
 	for _, d := range r.Deployments {
 		if d.Booted {
-			st.ImageRef = d.Origin
+			// Prefer container-image-reference (bootc-style); fall back to origin (legacy)
+			ref := d.ContainerImageRef
+			if ref == "" {
+				ref = d.Origin
+			}
+			// Strip ostree transport prefixes
+			ref = strings.TrimPrefix(ref, "ostree-unverified-registry:")
+			ref = strings.TrimPrefix(ref, "ostree-image-signed:docker://")
+			st.ImageRef = ref
 			st.Booted = d.Checksum
 			break
 		}
@@ -129,7 +134,8 @@ func CheckUpdates(ctx context.Context, runner cli.CommandRunner) (bool, string, 
 		if errors.Is(err, cli.ErrNotInstalled) {
 			return false, "", nil
 		}
-		return false, "", err
+		// bootc upgrade --check requires elevated privileges on some systems
+		return false, "bootc requires elevated privileges to check for updates; run: sudo bootc upgrade --check", nil
 	}
 	text := string(out)
 	available := strings.Contains(text, "Update available") || strings.Contains(text, "available")

--- a/internal/system/bootc_test.go
+++ b/internal/system/bootc_test.go
@@ -2,6 +2,7 @@ package system_test
 
 import (
 "context"
+"errors"
 "os"
 "testing"
 
@@ -64,16 +65,54 @@ t.Errorf("expected variant 'nvidia', got %q", status.Variant)
 }
 
 func TestGetSystemStatus_FallsBackToRpmOstree(t *testing.T) {
+rpmJSON := []byte(`{"deployments":[{"booted":true,"checksum":"abc123","origin":"","container-image-reference":"ostree-unverified-registry:ghcr.io/ublue-os/bluefin:stable"}]}`)
+
+t.Run("bootc_not_installed", func(t *testing.T) {
 mock := cli.NewMockExecutor()
 mock.SetResponse("bootc", []string{"status", "--json"}, nil, cli.ErrNotInstalled)
-mock.SetResponse("rpm-ostree", []string{"status", "--json"}, []byte(`{"deployments":[{"booted":true,"checksum":"abc","origin":"ghcr.io/ublue-os/bluefin:stable"}]}`), nil)
-
+mock.SetResponse("rpm-ostree", []string{"status", "--json"}, rpmJSON, nil)
 status, err := system.GetSystemStatus(context.Background(), mock)
 if err != nil {
 t.Fatalf("unexpected error: %v", err)
 }
-if status.ImageRef == "" {
-t.Error("should parse image ref from rpm-ostree fallback")
+if status.ImageRef != "ghcr.io/ublue-os/bluefin:stable" {
+t.Errorf("unexpected image ref: %q", status.ImageRef)
+}
+})
+
+t.Run("bootc_permission_error", func(t *testing.T) {
+mock := cli.NewMockExecutor()
+mock.SetResponse("bootc", []string{"status", "--json"}, nil, errors.New("exit status 1"))
+mock.SetResponse("rpm-ostree", []string{"status", "--json"}, rpmJSON, nil)
+status, err := system.GetSystemStatus(context.Background(), mock)
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+if status.ImageRef != "ghcr.io/ublue-os/bluefin:stable" {
+t.Errorf("want ghcr.io/ublue-os/bluefin:stable, got %q", status.ImageRef)
+}
+if status.Source != "rpm-ostree" {
+t.Errorf("expected source rpm-ostree, got %q", status.Source)
+}
+})
+}
+
+func TestParseRpmOstreeJSON_ContainerImageRef(t *testing.T) {
+// Verify the container-image-reference field is used and prefix is stripped.
+// Live systems show origin="" and container-image-reference="ostree-unverified-registry:ghcr.io/..."
+rpmJSON := []byte(`{"deployments":[{"booted":true,"checksum":"xyz","origin":"","container-image-reference":"ostree-unverified-registry:ghcr.io/ublue-os/bluefin-dx:lts"}]}`)
+mock := cli.NewMockExecutor()
+mock.SetResponse("bootc", []string{"status", "--json"}, nil, errors.New("exit status 1"))
+mock.SetResponse("rpm-ostree", []string{"status", "--json"}, rpmJSON, nil)
+status, err := system.GetSystemStatus(context.Background(), mock)
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+if status.ImageRef != "ghcr.io/ublue-os/bluefin-dx:lts" {
+t.Errorf("prefix not stripped, got %q", status.ImageRef)
+}
+if status.Variant != "dx" {
+t.Errorf("variant detection failed on rpm-ostree path, got %q", status.Variant)
 }
 }
 

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -11,7 +11,7 @@ import (
 	"github.com/projectbluefin/bluefin-mcp/internal/system"
 )
 
-// Register adds all 11 MCP tool handlers to the server.
+// Register adds all 12 MCP tool handlers to the server.
 func Register(s *server.MCPServer, runner cli.CommandRunner, store *system.KnowledgeStore) {
 	s.AddTool(mcp.NewTool("get_system_status",
 		mcp.WithDescription("Get atomic OCI image state: booted image, digest, staged update, variant"),

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -1,0 +1,343 @@
+package tools_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+	"github.com/projectbluefin/bluefin-mcp/internal/cli"
+	"github.com/projectbluefin/bluefin-mcp/internal/system"
+	"github.com/projectbluefin/bluefin-mcp/internal/tools"
+)
+
+// callTool sends a JSON-RPC tools/call request to the server and returns the
+// parsed CallToolResult. It fails the test if the transport or JSON layer errors.
+func callTool(t *testing.T, s *mcpserver.MCPServer, toolName string, args map[string]any) *mcp.CallToolResult {
+	t.Helper()
+
+	req := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name":      toolName,
+			"arguments": args,
+		},
+	}
+	raw, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	msg := s.HandleMessage(context.Background(), raw)
+
+	resp, ok := msg.(mcp.JSONRPCResponse)
+	if !ok {
+		t.Fatalf("expected JSONRPCResponse, got %T: %+v", msg, msg)
+	}
+
+	result, ok := resp.Result.(*mcp.CallToolResult)
+	if !ok {
+		t.Fatalf("expected *mcp.CallToolResult, got %T: %+v", resp.Result, resp.Result)
+	}
+	return result
+}
+
+// textOf extracts the text from the first Content item in a CallToolResult.
+func textOf(t *testing.T, result *mcp.CallToolResult) string {
+	t.Helper()
+	if len(result.Content) == 0 {
+		t.Fatal("CallToolResult has no content")
+	}
+	tc, ok := result.Content[0].(mcp.TextContent)
+	if !ok {
+		t.Fatalf("expected TextContent, got %T", result.Content[0])
+	}
+	return tc.Text
+}
+
+// newTestServer creates an MCPServer with all tools registered, using the
+// provided mock executor and a KnowledgeStore backed by dir.
+func newTestServer(t *testing.T, mock cli.CommandRunner, dir string) *mcpserver.MCPServer {
+	t.Helper()
+	store, err := system.NewKnowledgeStore(dir)
+	if err != nil {
+		t.Fatalf("NewKnowledgeStore: %v", err)
+	}
+	s := mcpserver.NewMCPServer("test", "test")
+	tools.Register(s, mock, store)
+	return s
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+func TestGetSystemStatus(t *testing.T) {
+	data, err := os.ReadFile("../../testdata/bootc-status.json")
+	if err != nil {
+		t.Fatalf("missing testdata: %v", err)
+	}
+
+	mock := cli.NewMockExecutor()
+	mock.SetResponse("bootc", []string{"status", "--json"}, data, nil)
+
+	s := newTestServer(t, mock, t.TempDir())
+	result := callTool(t, s, "get_system_status", nil)
+
+	if result.IsError {
+		t.Fatalf("tool returned error: %s", textOf(t, result))
+	}
+
+	text := textOf(t, result)
+	var out map[string]any
+	if err := json.Unmarshal([]byte(text), &out); err != nil {
+		t.Fatalf("result not valid JSON: %v\nraw: %s", err, text)
+	}
+
+	if out["Variant"] != "base" {
+		t.Errorf("expected variant 'base', got %v", out["Variant"])
+	}
+	if out["ImageRef"] != "ghcr.io/ublue-os/bluefin:stable" {
+		t.Errorf("unexpected image_ref: %v", out["ImageRef"])
+	}
+	if out["Booted"] == "" || out["Booted"] == nil {
+		t.Error("booted digest should not be empty")
+	}
+}
+
+func TestCheckUpdates_NoUpdate(t *testing.T) {
+	mock := cli.NewMockExecutor()
+	// bootc upgrade --check exits 0 with a message that does NOT contain
+	// "available" when up-to-date (CheckUpdates keys off that substring).
+	mock.SetResponse("bootc", []string{"upgrade", "--check"}, []byte("System image is current."), nil)
+
+	s := newTestServer(t, mock, t.TempDir())
+	result := callTool(t, s, "check_updates", nil)
+
+	if result.IsError {
+		t.Fatalf("tool returned error: %s", textOf(t, result))
+	}
+
+	text := textOf(t, result)
+	var out map[string]any
+	if err := json.Unmarshal([]byte(text), &out); err != nil {
+		t.Fatalf("result not valid JSON: %v\nraw: %s", err, text)
+	}
+
+	available, _ := out["available"].(bool)
+	if available {
+		t.Errorf("expected available=false, got true; message: %v", out["message"])
+	}
+	if out["message"] == nil || out["message"] == "" {
+		t.Error("expected non-empty message field")
+	}
+}
+
+func TestGetFlatpakList(t *testing.T) {
+	data, err := os.ReadFile("../../testdata/flatpak-list.txt")
+	if err != nil {
+		t.Fatalf("missing testdata: %v", err)
+	}
+
+	mock := cli.NewMockExecutor()
+	mock.SetResponse("flatpak", []string{"list", "--columns=application,version"}, data, nil)
+
+	s := newTestServer(t, mock, t.TempDir())
+	result := callTool(t, s, "get_flatpak_list", nil)
+
+	if result.IsError {
+		t.Fatalf("tool returned error: %s", textOf(t, result))
+	}
+
+	text := textOf(t, result)
+	var apps []map[string]any
+	if err := json.Unmarshal([]byte(text), &apps); err != nil {
+		t.Fatalf("result not valid JSON array: %v\nraw: %s", err, text)
+	}
+	if len(apps) == 0 {
+		t.Fatal("expected at least one flatpak app")
+	}
+	first := apps[0]
+	if first["AppID"] == "" || first["AppID"] == nil {
+		t.Error("expected non-empty AppID in first app")
+	}
+	if first["Version"] == "" || first["Version"] == nil {
+		t.Error("expected non-empty Version in first app")
+	}
+}
+
+func TestGetBrewPackages_BrewNotInstalled(t *testing.T) {
+	// MockExecutor returns ErrNotInstalled for any unregistered command.
+	mock := cli.NewMockExecutor()
+	// No "brew" response registered → ErrNotInstalled
+
+	s := newTestServer(t, mock, t.TempDir())
+	result := callTool(t, s, "get_brew_packages", nil)
+
+	// When brew is not installed the tool returns nil, nil → JSON null → no error
+	if result.IsError {
+		t.Fatalf("tool returned error for missing brew (expected graceful nil): %s", textOf(t, result))
+	}
+
+	text := textOf(t, result)
+	// Result should be JSON null (no brew) or an empty array — both are valid.
+	// The key requirement is no IsError flag and parseable JSON.
+	if text != "null" && text != "[]" {
+		var arr []any
+		if err := json.Unmarshal([]byte(text), &arr); err != nil {
+			t.Errorf("unexpected result for missing brew: %q", text)
+		}
+	}
+}
+
+func TestListDistrobox_NotInstalled(t *testing.T) {
+	// No "distrobox" response → ErrNotInstalled → graceful nil
+	mock := cli.NewMockExecutor()
+
+	s := newTestServer(t, mock, t.TempDir())
+	result := callTool(t, s, "list_distrobox", nil)
+
+	if result.IsError {
+		t.Fatalf("tool returned error for missing distrobox (expected graceful nil): %s", textOf(t, result))
+	}
+	// Should be null or [] — just verify parseable JSON
+	text := textOf(t, result)
+	var v any
+	if err := json.Unmarshal([]byte(text), &v); err != nil {
+		t.Errorf("result not valid JSON: %v\nraw: %s", err, text)
+	}
+}
+
+func TestGetUnitDocs_SeedData(t *testing.T) {
+	// NewKnowledgeStore pre-populates seed data; no mock commands needed for this tool.
+	mock := cli.NewMockExecutor()
+	s := newTestServer(t, mock, t.TempDir())
+
+	result := callTool(t, s, "get_unit_docs", map[string]any{
+		"unit_name": "flatpak-nuke-fedora.service",
+	})
+
+	if result.IsError {
+		t.Fatalf("tool returned error: %s", textOf(t, result))
+	}
+
+	text := textOf(t, result)
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(text), &doc); err != nil {
+		t.Fatalf("result not valid JSON: %v\nraw: %s", err, text)
+	}
+	if doc["name"] != "flatpak-nuke-fedora.service" {
+		t.Errorf("expected name 'flatpak-nuke-fedora.service', got %v", doc["name"])
+	}
+	if doc["description"] == nil || doc["description"] == "" {
+		t.Error("expected non-empty description from seed data")
+	}
+}
+
+func TestStoreAndListUnitDocs_Roundtrip(t *testing.T) {
+	mock := cli.NewMockExecutor()
+	s := newTestServer(t, mock, t.TempDir())
+
+	// Store a new unit doc
+	storeResult := callTool(t, s, "store_unit_docs", map[string]any{
+		"unit_name":   "my-custom.service",
+		"description": "My custom test service",
+		"variant":     "dx",
+	})
+	if storeResult.IsError {
+		t.Fatalf("store_unit_docs returned error: %s", textOf(t, storeResult))
+	}
+
+	var stored map[string]any
+	if err := json.Unmarshal([]byte(textOf(t, storeResult)), &stored); err != nil {
+		t.Fatalf("store result not valid JSON: %v", err)
+	}
+	if stored["status"] != "stored" {
+		t.Errorf("expected status 'stored', got %v", stored["status"])
+	}
+	if stored["unit"] != "my-custom.service" {
+		t.Errorf("expected unit 'my-custom.service', got %v", stored["unit"])
+	}
+
+	// List all docs and verify the new unit appears
+	listResult := callTool(t, s, "list_unit_docs", nil)
+	if listResult.IsError {
+		t.Fatalf("list_unit_docs returned error: %s", textOf(t, listResult))
+	}
+
+	var docs []map[string]any
+	if err := json.Unmarshal([]byte(textOf(t, listResult)), &docs); err != nil {
+		t.Fatalf("list result not valid JSON array: %v", err)
+	}
+
+	var found bool
+	for _, d := range docs {
+		if d["name"] == "my-custom.service" {
+			found = true
+			if d["description"] != "My custom test service" {
+				t.Errorf("wrong description: got %v", d["description"])
+			}
+			if d["variant"] != "dx" {
+				t.Errorf("wrong variant: got %v", d["variant"])
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("stored unit 'my-custom.service' not found in list_unit_docs output")
+	}
+}
+
+func TestGetHardwareReport_AMDGPUNoIssues(t *testing.T) {
+	lspci, err := os.ReadFile("../../testdata/lspci-nnk-amd-intel.txt")
+	if err != nil {
+		t.Fatalf("missing testdata: %v", err)
+	}
+	bootcData, err := os.ReadFile("../../testdata/bootc-status.json")
+	if err != nil {
+		t.Fatalf("missing testdata: %v", err)
+	}
+
+	mock := cli.NewMockExecutor()
+	mock.SetResponse("lspci", []string{"-nnk"}, lspci, nil)
+	mock.SetResponse("cat", []string{"/proc/cmdline"}, []byte("BOOT_IMAGE=/vmlinuz root=/dev/mapper/fedora-root"), nil)
+	mock.SetResponse("cat", []string{"/sys/class/dmi/id/product_name"}, []byte("Framework Laptop 13"), nil)
+	mock.SetResponse("cat", []string{"/sys/class/dmi/id/chassis_type"}, []byte("10"), nil)
+	mock.SetResponse("cat", []string{"/sys/class/dmi/id/bios_version"}, []byte("03.05"), nil)
+	mock.SetResponse("bootc", []string{"status", "--json"}, bootcData, nil)
+
+	s := newTestServer(t, mock, t.TempDir())
+	result := callTool(t, s, "get_hardware_report", nil)
+
+	if result.IsError {
+		t.Fatalf("tool returned error: %s", textOf(t, result))
+	}
+
+	text := textOf(t, result)
+	var report map[string]any
+	if err := json.Unmarshal([]byte(text), &report); err != nil {
+		t.Fatalf("result not valid JSON: %v\nraw: %s", err, text)
+	}
+
+	// AMD GPU on base variant — no compatibility warnings expected
+	compat, ok := report["variant_compat"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected variant_compat object, got %T: %v", report["variant_compat"], report["variant_compat"])
+	}
+	if nv, _ := compat["nvidia_detected"].(bool); nv {
+		t.Error("expected NvidiaDetected=false for AMD GPU")
+	}
+
+	// issues should be empty or absent for a clean AMD system on base
+	issues, _ := report["issues"].([]any)
+	for _, iss := range issues {
+		t.Logf("hardware issue reported: %v", iss)
+	}
+
+	// system sub-object should be present
+	if report["system"] == nil {
+		t.Error("expected 'system' field in hardware report")
+	}
+}


### PR DESCRIPTION
## Summary

Three bugs found via live testing on Bluefin DX (bootc 1.13.0, kernel 6.17.12).

### Bug 1 — MCP responses went to stderr (server completely silent to clients)
`os.Stdout = os.Stderr` ran before `ServeStdio()` captured `os.Stdout`. Every JSON-RPC response was written to stderr. No MCP client could receive any data.

**Fix:** Remove the redirect entirely. All `fmt.Fprintf` calls already use `os.Stderr` explicitly. `log.SetOutput(os.Stderr)` added as belt-and-suspenders. `ServeStdio` uses real stdout directly.

### Bug 2 — `get_system_status` / `get_boot_health` failed silently on bootc 1.13.0
bootc 1.13.0 requires root for all subcommands. The rpm-ostree fallback only triggered on `ErrNotInstalled`, not permission errors — so the error propagated to the client as raw "exit status 1".

Also: the rpm-ostree JSON parser read the empty `origin` field instead of `container-image-reference` (e.g. `ostree-unverified-registry:ghcr.io/ublue-os/bluefin-dx:lts-hwe-testing`).

**Fix:** Fall back to rpm-ostree on any bootc failure. Parse `container-image-reference` with transport-prefix stripping. `check_updates` returns a helpful human-readable message instead of raw error.

### Bug 3 — `get_hardware_report` crashed with "bad file descriptor" (GC race)
`os.NewFile(1, ...)` wraps fd 1 without `dup`-ing it. When `os.Stdout = os.Stderr` dropped the last reference to the original `os.Stdout`, Go's finalizer closed fd 1. Slower tools like `get_hardware_report` gave GC time to trigger it during tool execution.

**Fix:** Same as Bug 1 — removing the redirect eliminates this entirely.

## New test coverage
- `internal/tools/tools_test.go` — 8 tests (previously **zero** coverage for the tools layer)
- `internal/system/bootc_test.go` — 2 new sub-tests: permission-error fallback + `container-image-reference` prefix stripping

## Live verification (on this machine)
All 12 tools tested individually:
```
✅ get_system_status    → ImageRef: ghcr.io/ublue-os/bluefin-dx:lts-hwe-testing, Variant: dx
✅ check_updates        → available: false, message: helpful root message
✅ get_boot_health      → image_ref, rollback_available, variant
✅ get_variant_info     → variant: dx
✅ list_recipes         → list[30]
✅ get_flatpak_list     → list[111]
✅ get_brew_packages    → list[359]
✅ list_distrobox       → None (none running)
✅ list_unit_docs       → list[12]
✅ get_unit_docs        → flatpak-nuke-fedora.service doc returned
✅ get_hardware_report  → system, critical_devices, variant_compat, issues
✅ store_unit_docs      → stored
```