### PR TITLE
improvement: embed build date in binary and add context to JSON parse errors

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,7 +1,7 @@
 default: build
 
 build:
-    go build -o bin/bluefin-mcp ./cmd/bluefin-mcp
+    go build -ldflags "-X main.buildDate=$(date -u +%Y-%m-%d)" -o bin/bluefin-mcp ./cmd/bluefin-mcp
 
 install: build
     cp bin/bluefin-mcp ~/.local/bin/bluefin-mcp

--- a/cmd/bluefin-mcp/main.go
+++ b/cmd/bluefin-mcp/main.go
@@ -12,7 +12,10 @@ import (
 	"github.com/projectbluefin/bluefin-mcp/internal/tools"
 )
 
-var version = "dev"
+var (
+	version   = "dev"
+	buildDate = "unknown" // injected at build time via -ldflags "-X main.buildDate=YYYY-MM-DD"
+)
 
 func main() {
 	// All logging must go to stderr — stdout is reserved for the JSON-RPC
@@ -39,6 +42,7 @@ func main() {
 
 	runner := cli.NewRealExecutor()
 	s := server.NewMCPServer("bluefin-mcp", version)
+	tools.BuildDate = buildDate
 	tools.Register(s, runner, store)
 
 	if err := server.ServeStdio(s); err != nil {

--- a/internal/system/bootc.go
+++ b/internal/system/bootc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/projectbluefin/bluefin-mcp/internal/cli"
@@ -69,7 +70,7 @@ func GetSystemStatus(ctx context.Context, runner cli.CommandRunner) (*SystemStat
 func parseBootcJSON(data []byte) (*SystemStatus, error) {
 	var s bootcStatusJSON
 	if err := json.Unmarshal(data, &s); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("bootc status returned unparseable JSON (is bootc up to date?): %w", err)
 	}
 	st := &SystemStatus{Source: "bootc"}
 	if s.Status.Booted != nil {
@@ -87,7 +88,7 @@ func parseBootcJSON(data []byte) (*SystemStatus, error) {
 func parseRpmOstreeJSON(data []byte) (*SystemStatus, error) {
 	var r rpmOstreeJSON
 	if err := json.Unmarshal(data, &r); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("rpm-ostree status returned unparseable JSON (is rpm-ostree up to date?): %w", err)
 	}
 	st := &SystemStatus{Source: "rpm-ostree"}
 	for _, d := range r.Deployments {

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -11,6 +11,9 @@ import (
 	"github.com/projectbluefin/bluefin-mcp/internal/system"
 )
 
+// BuildDate is set from main via ldflags so AI clients can report corpus freshness.
+var BuildDate = "unknown"
+
 // Register adds all 11 MCP tool handlers to the server.
 func Register(s *server.MCPServer, runner cli.CommandRunner, store *system.KnowledgeStore) {
 	s.AddTool(mcp.NewTool("get_system_status",
@@ -158,6 +161,7 @@ func Register(s *server.MCPServer, runner cli.CommandRunner, store *system.Knowl
 		return jsonResult(map[string]any{
 			"results":     results,
 			"corpus_date": corpusDate,
+			"build_date":  BuildDate,
 			"count":       len(results),
 		})
 	})


### PR DESCRIPTION
## Summary

- **Build date (#35):** Adds `buildDate` to `main.go` (injected via `-ldflags "-X main.buildDate=YYYY-MM-DD"`), exposes it as `tools.BuildDate`, and includes `"build_date"` in every `search_discussions` response alongside the existing `"corpus_date"`. AI clients can now caveat results with binary freshness. Updates Justfile `build` recipe to inject the date at build time.

- **Parse error context (#34):** `parseBootcJSON` and `parseRpmOstreeJSON` previously returned bare JSON syntax errors with no context. Now wrapped:
  - `"bootc status returned unparseable JSON (is bootc up to date?): ..."`
  - `"rpm-ostree status returned unparseable JSON (is rpm-ostree up to date?): ..."`

Closes #35
Closes #34

## Test plan
- [ ] `just build` injects today's date into the binary
- [ ] `go test ./...` passes
- [ ] `search_discussions` response JSON includes `"build_date"` field
- [ ] Invalid bootc JSON returns an actionable error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)