### PR TITLE
fix(ci): resolve refresh-testdata workflow file issue (#3)

### DIFF
--- a/.github/workflows/refresh-testdata.yml
+++ b/.github/workflows/refresh-testdata.yml
@@ -37,8 +37,7 @@ jobs:
           if git diff --cached --quiet; then
             echo "No changes to commit — testdata is already up to date."
           else
-            git commit -m "chore: refresh testdata from Bluefin source repos [skip ci]
-
-$(cat testdata/refresh-manifest.json)"
+            MANIFEST=$(cat testdata/refresh-manifest.json)
+            git commit -m "chore: refresh testdata from Bluefin source repos [skip ci]" -m "${MANIFEST}"
             git push
           fi


### PR DESCRIPTION
## Summary

Fixes the `.github/workflows/refresh-testdata.yml` workflow file issue reported in #3.

The inline shell command substitution `$(cat testdata/refresh-manifest.json)` inside a YAML multiline string caused GitHub Actions YAML parsing failures on first push. The fix captures the manifest content into a variable first, then passes it as a separate `-m` argument to `git commit`.

## Changes

- `.github/workflows/refresh-testdata.yml`: replace inline heredoc `$()` with captured variable `MANIFEST` + separate `-m` arg

Closes #3

## Test plan

- [ ] Trigger `workflow_dispatch` on the `refresh-testdata` workflow to verify it no longer fails with 'workflow file issue'
- [ ] Confirm CI (`ci.yml`) remains green

🤖 Generated with [Claude Code](https://claude.com/claude-code)