### PR TITLE
docs: add linux-mcp-server boundary reference table (#7)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,27 @@ just lint           # go vet ./... && staticcheck ./...
 bash scripts/refresh-testdata.sh   # regenerate golden files from upstream Bluefin repos
 ```
 
+## Server Boundary: linux-mcp-server vs bluefin-mcp
+
+Before adding any tool, check what [linux-mcp-server](https://github.com/rhel-lightspeed/linux-mcp-server) already covers:
+
+| linux-mcp-server tool | Covers |
+|---|---|
+| `get_system_information` | hostname, OS, kernel, uptime |
+| `get_cpu_information` | CPU model, cores, frequency, load averages |
+| `get_memory_information` | RAM and swap usage |
+| `get_disk_usage` | filesystem usage for all mount points |
+| `get_hardware_information` | lspci (bare, no `-nnk` flags), lscpu, lsusb, dmidecode |
+| `get_service_status` / `get_service_logs` | systemd unit status and journalctl |
+| `get_journal_logs` | journalctl queries |
+| `get_network_interfaces` / `get_network_connections` | network state |
+| `list_processes` / `get_process_info` | process list |
+| `read_file` | reads files from allowlisted paths (covers `/etc`) |
+
+**Critical gap:** linux-mcp-server runs `lspci` with no flags — no `-nn` (PCI IDs) and no `-k` (kernel modules). Output is truncated to 50 lines. This is why `get_hardware_report` uses `lspci -nnk`.
+
+**Decision rule:** If the data is a generic Linux fact, it belongs in linux-mcp-server. If interpreting that fact requires knowing what Bluefin is, it belongs here.
+
 ## Critical Rules
 
 - **Design law** — every tool must be grounded in `projectbluefin/common`, `ublue-os/bluefin`, or `docs.projectbluefin.io`; no generic Linux assumptions


### PR DESCRIPTION
## Summary\n\nAdds the formal linux-mcp-server / bluefin-mcp division-of-responsibility reference to AGENTS.md, as requested in #7.\n\nEvery linux-mcp-server tool is listed with what it covers, plus the critical gap (lspci without `-nnk` flags, 50-line truncation) and the decision rule for where new tools belong.\n\nThis complements the server boundary section in the CONTRIBUTING.md added by #41.\n\nCloses #7\n\n## Test plan\n\n- [x] Table covers every linux-mcp-server tool from the agent investigation (2026-03-20)\n- [x] lspci flag gap is documented\n- [x] Decision rule for tool placement is clear\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)