### PR TITLE
fix(ci): avoid shell expansion in refresh-testdata commit step (#3)

### DIFF
--- a/.github/workflows/refresh-testdata.yml
+++ b/.github/workflows/refresh-testdata.yml
@@ -37,8 +37,7 @@ jobs:
           if git diff --cached --quiet; then
             echo "No changes to commit — testdata is already up to date."
           else
-            git commit -m "chore: refresh testdata from Bluefin source repos [skip ci]
-
-$(cat testdata/refresh-manifest.json)"
+            MANIFEST=$(cat testdata/refresh-manifest.json)
+            git commit -m "chore: refresh testdata from Bluefin source repos [skip ci]" -m "${MANIFEST}"
             git push
           fi


### PR DESCRIPTION
## Summary

Fixes the `refresh-testdata.yml` workflow file parsing failure reported in #3.

The inline `$(cat testdata/refresh-manifest.json)` inside the YAML literal block scalar caused GitHub Actions to report `This run likely failed because of a workflow file issue` on first push.

Replaced with a standard two-part `git commit -m` — subject line separate from body — reading the manifest into a variable first.

## Changes

- `.github/workflows/refresh-testdata.yml`: replace inline shell expansion with `MANIFEST=$(cat ...)` variable + `-m "subject" -m "${MANIFEST}"`

Closes #3