### PR TITLE
docs(seed): enhance ublue-user-setup.service entry with PATH/SSH context (#17)

### DIFF
--- a/internal/seed/units.json
+++ b/internal/seed/units.json
@@ -15,7 +15,7 @@
     "ublue-user-setup.service": {
       "name": "ublue-user-setup.service",
       "variant": "all",
-      "description": "Configure system for current user Source: projectbluefin/common@4170fe6"
+      "description": "Configures the user environment at login: extends PATH for Homebrew (/home/linuxbrew/.linuxbrew/bin), sets up shell integration, and applies user-scoped systemd presets.\n\nNon-interactive SSH sessions (VS Code Remote, JetBrains Gateway) may not source profile.d scripts, so brew, docker, and Homebrew tools can appear missing even when installed. The fix is to ensure the remote shell sources /etc/profile.d/brew.sh or to add the Homebrew bin directory to PATH in ~/.bashrc or ~/.zshrc explicitly.\n\nRelated: get_brew_packages (confirm packages exist), get_system_status (verify booted deployment), list_recipes (check for SSH setup recipes)"
     },
     "dconf-update.service": {
       "name": "dconf-update.service",


### PR DESCRIPTION
## Summary

Enhances the `ublue-user-setup.service` knowledge store entry to explain:

- **What it does**: Extends PATH for Homebrew (`/home/linuxbrew/.linuxbrew/bin`), sets up shell integration, applies user-scoped systemd presets
- **The SSH gotcha**: Non-interactive SSH sessions (VS Code Remote, JetBrains Gateway) may not source `/etc/profile.d/` scripts, so brew/docker/Homebrew tools appear missing even when installed
- **The fix**: Ensure the remote shell sources `/etc/profile.d/brew.sh` or add Homebrew bin to PATH in `~/.bashrc`/`~/.zshrc`
- **Related tools**: `get_brew_packages`, `get_system_status`, `list_recipes`

Closes #17